### PR TITLE
Docs: add local development setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,58 @@ Monorepo boilerplate for a Habit Tracker web app.
 - Node.js 20+
 - npm 10+
 
-## Install
+## Local development setup
+
+### 1) Clone the repository
+
+```bash
+git clone https://github.com/trial-account-o6/Habit-Tracker-Website.git
+cd Habit-Tracker-Website
+```
+
+### 2) Install dependencies
+
+Install all workspace dependencies from the repo root:
 
 ```bash
 npm install
 ```
 
-## Run in development
+### 3) Start the app in development mode
+
+Run frontend and backend together from the root:
 
 ```bash
 npm run dev
 ```
 
-- Frontend: http://localhost:5173
-- Backend: http://localhost:3001/health
+Services:
 
-## Build
+- Frontend: http://localhost:5173
+- Backend health endpoint: http://localhost:3001/health
+
+### 4) Build the project
 
 ```bash
 npm run build
+```
+
+## Useful workspace commands
+
+Run frontend only:
+
+```bash
+npm run dev -w frontend
+```
+
+Run backend only:
+
+```bash
+npm run dev -w backend
+```
+
+Run tests:
+
+```bash
+npm run test
 ```


### PR DESCRIPTION
## Summary
This PR updates `README.md` with clearer local development setup instructions.

## What changed
- Added a dedicated **Local development setup** section with:
  - clone + `cd` steps
  - dependency installation from monorepo root
  - running frontend and backend together
  - service URLs for quick verification
  - build command
- Added useful workspace-specific commands:
  - frontend only
  - backend only
  - tests

Closes #2